### PR TITLE
fix: run the contentScript on all frames in the page

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,5 +3,8 @@
     "ignorePatterns":["lib/*"],
     "env":{
         "webextensions": true
+    },
+    "rules": {
+        "testing-library/no-dom-import": "off"
     }
 }

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -16,6 +16,7 @@
   "web_accessible_resources": ["dist/globals.js"],
   "content_scripts": [
     {
+      "all_frames": true,
       "matches": ["<all_urls>"],
       "js": ["dist/contentScript.js"]
     }

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -24,7 +24,7 @@ Bridge.onMessage("run-query-in-console", ({ data: { query } }) => {
 });
 
 chrome.runtime.onMessage.addListener((request) => {
-  if (request.type == "getSuggestedQuery") {
+  if (request.type == "getSuggestedQuery" && currentElement) {
     const suggestedQuery = getSuggestionFor(currentElement, request.variant); //getClosestQuery(currentElement, request.variant);
     if (suggestedQuery) {
       const queryToCopy = `screen.${suggestedQuery.toString()}`;
@@ -40,6 +40,9 @@ chrome.runtime.onMessage.addListener((request) => {
       document.execCommand("copy");
       hiddenInput.remove();
       currentEl.focus();
+
+      // Clear the currentElement since we run on multiple frames
+      currentElement = null;
     }
   }
 });


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: The `contentScript` will now run on all frames since when using iframes the `contextmenu` event doesn't bubble.

<!-- Why are these changes necessary? -->

**Why**: Solves https://github.com/testing-library/which-query/issues/16

<!-- How were these changes implemented? -->

**How**: Add the `all_frames: true` flag to the manifest.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Would love to hear your opinions @benmonro, @nickmccurdy, @kentcdodds, @smeijer 
